### PR TITLE
Spawn fix for Ares (WebOS)

### DIFF
--- a/lib/modules/ares.js
+++ b/lib/modules/ares.js
@@ -9,21 +9,20 @@ class ARES extends Module {
 
         let ares_ = E.utils.whereis('ares').shift();
         if(!ares_) {
-            console.log('ares not found; please make sure ares executables are in the PATH environment variable...');
+            console.log('ares not found; please make sure ares executables are in the PATH environment variable...'.red);
             process.exit(1);
         }
-
+        
         E.log('Using ares at',ares_);
     }
 
-    $(type, ...args) {
-        return this.utils.spawn('cmd.exe',['/C',`ares-${type}.cmd`, ...args], { cwd : this.options.root || this.core.BUILD, stdio : 'inherit' });
+    async $(type, ...args) {
+        await this.E.utils.spawn('cmd.exe',['/C',`ares-${type}.cmd`, ...args], { cwd : this.options.root || this.core.BUILD, stdio : 'inherit' });
     }
-
-    package(...args) { return this.$('package', ...args); }
-    install(...args) { return this.$('install', ...args); }
-    launch(...args) { return this.$('launch', ...args); }
-    inspect(...args) { return this.$('inspect', ...args); }
+    async package(...args) { return this.$('package', ...args); }
+    async install(...args) { return this.$('install', ...args); }
+    async launch(...args) { return this.$('launch', ...args); }
+    async inspect(...args) { return this.$('inspect', ...args); }
 }
 
 exports.Resolver = (E) => {


### PR DESCRIPTION
Looks like utils was moved since webos support was added. Also required a small change in soar-webos https://github.com/LSI-SOAR/soar-webos-lg/commit/ee6317c 